### PR TITLE
Fix: Python region polygon creation assertion

### DIFF
--- a/python/trax/region.py
+++ b/python/trax/region.py
@@ -143,7 +143,8 @@ class Polygon(Region):
         super(Polygon, self).__init__(POLYGON)
         assert(isinstance(points, list))
         # do not allow empty list
-        assert(reduce(lambda x,y: x and y, [isinstance(p, tuple) for p in points], False))
+        assert(len(points) > 0)
+        assert(reduce(lambda x,y: x and y, [isinstance(p, tuple) for p in points]))
         self.count = len(points) 
         self.points = points
 


### PR DESCRIPTION
The previous assertion was always raised as the initial value of the
reduce was False, meaning that all subsequent values were and'd with it.
Changed this to first check that the list is not empty and then to check
that the list contains tuples.