### PR TITLE
updating expected result of sys.platform for linux platforms

### DIFF
--- a/support/python/trax/internal.py
+++ b/support/python/trax/internal.py
@@ -57,14 +57,14 @@ else:
     c_long_double_t = ctypes.c_ubyte*16
 
 _libraries = {}
-if sys.platform in ['linux1', 'linux2']:
+if sys.platform.startswith('linux'):
     _libraries['trax'] = ctypes.CDLL('libtrax.so')
 elif sys.platform in ['darwin']:
     _libraries['trax'] = ctypes.CDLL('libtrax.dynlib')
 elif sys.platform in ['win32']:
     _libraries['trax'] = ctypes.CDLL('trax.dll')
 else:
-    RuntimeError('Unsupported platform')
+    raise RuntimeError('Unsupported platform')
 
 class struct_trax_image(ctypes.Structure):
     _pack_ = True # source:False


### PR DESCRIPTION
1. changed expected result of sys.platform
From the python 3 sys documentation:
Changed in version 3.3: On Linux, sys.platform doesn’t contain the major version anymore. It is always 'linux', instead of 'linux2' or 'linux3'. Since older Python versions include the version number, it is recommended to always use the startswith idiom presented above.

2. raise RuntimeError so that it's visible in the log as an error

Should fix https://github.com/votchallenge/vot-toolkit/issues/224