### PR TITLE
converting from string to bytes and vice-versa

### DIFF
--- a/support/python/trax/__init__.py
+++ b/support/python/trax/__init__.py
@@ -43,13 +43,13 @@ class Properties(object):
         elif isinstance(data, dict):
             self._ref = PropertiesWrapper(trax_properties_create())
             for key, value in data.items():
-                trax_properties_set(self._ref.reference(), key, str(value))
+                trax_properties_set(self._ref.reference(), key.encode('utf8'), str(value).encode('utf8'))
 
     def __getitem__(self, key):
         return trax_properties_get(self._ref.reference(), key)
 
     def __setitem__(self, key, value):
-        trax_properties_set(self._ref.reference(), key, str(value))
+        trax_properties_set(self._ref.reference(), key.encode('utf8'), str(value).encode('utf8'))
 
     def get(self, key, default = None):
         value = trax_properties_get(self._ref.reference(), key)
@@ -58,7 +58,7 @@ class Properties(object):
         return value
 
     def set(self, key, value):
-        trax_properties_set(self._ref.reference(), key, str(value))
+        trax_properties_set(self._ref.reference(), key.encode('utf8'), str(value).encode('utf8'))
 
 from .server import Server
 from .region import *

--- a/support/python/trax/image.py
+++ b/support/python/trax/image.py
@@ -116,7 +116,7 @@ class FileImage(Image):
         return Image.PATH
 
     def path(self):
-        return trax_image_get_path(self._ref.reference())
+        return trax_image_get_path(self._ref.reference()).decode('utf8')
 
 class URLImage(Image):
     """ 


### PR DESCRIPTION
In python 3, the ctypes uses bytes instead of strings and must be explicitly converted. 

I believe this change should fix it. Compatibility with python2 should be checked but I believe this shouldn't break it. 

Should fix https://github.com/votchallenge/trax/issues/47 